### PR TITLE
Fix skin set problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.0-beta.22",
+  "version": "1.1.0-beta.23",
   "description": "galacean spine runtime",
   "name": "@galacean/engine-spine",
   "main": "dist/main.js",

--- a/src/SpineRenderer.ts
+++ b/src/SpineRenderer.ts
@@ -72,7 +72,10 @@ export class SpineRenderer extends Script {
         for (let i = 0, l = skins.length; i < l; ++i) {
           _skinNames.push(skins[i].name);
         }
-        this.skinName = this._skinName || _skinNames[0];
+        const skinName = this._skinName || _skinNames[0];
+        const { skeleton } = this._spineAnimation;
+        skeleton.setSkinByName(skinName);
+        skeleton.setSlotsToSetupPose();
 
         // 如果设置了自动播放，默认就播放第一个动画
         if (this._autoPlay && _animationNames.length > 0) {


### PR DESCRIPTION
The order of calling the resource setter and skinName setter of SpineRenderer is irrelevant. To prevent the skin from not being set correctly under such circumstances, if the skinName setter is called first, the _skinName variable will be stored. Later, when the resource setter is invoked, it tries to set the skin internally via the skinName setter. 
However, by this time, _skinName has already been stored and is the same as the argument passed to the setter, which causes the skin setting to fail. 
Therefore, the PR has improved this by setting the skin directly rather than through the skinName setter.